### PR TITLE
Feature: Nearby Presence Sensor

### DIFF
--- a/hubitat-teslamate.groovy
+++ b/hubitat-teslamate.groovy
@@ -428,7 +428,7 @@ def handleLocationEvent(data) {
     def distance = R * c; // distance in km
 
     // If the car is within 130 km, set the area presence sensor to true
-    def areaPresenceId = "${data.childId}-areaPresence"
+    def areaPresenceId = "${data.vehicleId}-areaPresence"
     def areaPresence = getChildDevice(areaPresenceId)
     if( !areaPresence ) {
         // Child device doesn't exist; need to create it.

--- a/hubitat-teslamate.groovy
+++ b/hubitat-teslamate.groovy
@@ -420,7 +420,7 @@ def handleLocationEvent(data) {
     final int R = 6371; // Radius of the earth
 
     def latDistance = Math.toRadians(homeLat - carLat);
-    def lonDistance = Math.toRadians(homeLat - carLat);
+    def lonDistance = Math.toRadians(homeLon - carLon);
     def a = (Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
             + Math.cos(Math.toRadians(carLat)) * Math.cos(Math.toRadians(homeLat))
             * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2))
@@ -449,12 +449,15 @@ def handleLocationEvent(data) {
     if( cd.currentValue("geofence") != settings?.homeGeofence ) {
         def numHoursAway = distance / 130
         def timeToNextCheck = Math.max( Math.abs(numHoursAway - 1), 0.1 )
-        debug("[d:handleLocationEvent] distance: ${distance} km, check in ${(int) (60 * timeToNextCheck)} minutes")
+        debug("[d:handleLocationEvent] distance: ${(int) distance} km, check in ${(int) (60 * timeToNextCheck)} minutes")
         runIn((long) (60 * 60 * timeToNextCheck), "startProximityCheck", [
             data: [
                 vehicleId: vehicleId
             ]
         ])
+    }
+    else {
+        debug("[d:handleLocationEvent] No check scheduled; car is at home")
     }
 }
 

--- a/hubitat-teslamate.groovy
+++ b/hubitat-teslamate.groovy
@@ -436,7 +436,7 @@ def handleLocationEvent(data) {
             "hubitat",
             "Generic Component Presence Sensor",
             areaPresenceId,
-            [name: "${cd.getLabel()} Nearby", isComponent: true]
+            [name: "${cd.getLabel()} Nearby", isComponent: false]
         )
     }
     areaPresence.setLabel("${cd.getLabel()} Nearby")
@@ -462,7 +462,10 @@ def handleLocationEvent(data) {
 }
 
 def componentRefresh(child) {
-    return
+    if( child.deviceNetworkId.endsWith("-areaPresence") ) {
+        // Area presence sensor; refresh
+        startProximityCheck([vehicleId: child.deviceNetworkId.minus("-areaPresence")])
+    }
 }
 
 // ========================================================

--- a/hubitat-teslamate.groovy
+++ b/hubitat-teslamate.groovy
@@ -202,6 +202,16 @@ void initialize() {
             for( vehicle in vehicles ) {
                 startProximityCheck([vehicleId: vehicle])
             }
+            getChildDevices().collect{ it.deviceNetworkId }.
+                // Keep known vehicles
+                minus(childIds.collect {[thisId, it].join("-")}).
+                // Keep area presence sensors for known vehicles
+                minus(childIds.collect {[it, "areaPresence"].join("-")}).
+                // Delete everything else
+                each {
+                    debug("Removing unknown child device ${it}}")
+                    deleteChildDevice(it)
+                };
         }
         connected()
     } catch(Exception e) {
@@ -408,6 +418,11 @@ def handleLocationEvent(data) {
     def carLon = cd.currentValue("longitude")
     def homeLat = location.latitude.doubleValue()
     def homeLon = location.longitude.doubleValue()
+
+    if( !carLat || !carLon ) {
+        debug("[d:handleLocationEvent] Don't know car location yet!");
+        return
+    }
 
     debug("[d:handleLocationEvent] carLat: ${carLat}, carLon: ${carLon}, homeLat: ${homeLat}, homeLon: ${homeLon}")
 


### PR DESCRIPTION
In addition to the car's default presence sensor, which indicates whether the car is at home, this creates an optional coarser presence sensor to indicate whether the car is "local." Some automations that look at the car's state only matter if the car is likely to return home (i.e. to charge), and could use this sensor to ignore the car's data.